### PR TITLE
Develop : Vercelの設定を追加

### DIFF
--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -9,6 +9,7 @@ const options = {
 const client = applyCaseMiddleware(
   axios.create({
     baseURL: 'https://e-code-back.herokuapp.com/api/v1'
+    // baseURL: 'http://localhost:8080/api/v1'
   }),
   options
 )

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/:path*", "destination": "/index.html" }]
+}


### PR DESCRIPTION
# 概要
Vercel.jsonを追加し、index.htmlのパスが切れない設定を追加。

# 挙動
SPAの仕様でデプロイしたアプリケーションにて、/以外のページで更新した場合にパスが切れて404になる。

## 対処
vercel.jsonを作成し、以下を追加。
```
 {
   "rewrites": [{ "source": "/:path*", "destination": "/index.html" }]
 }
```

# 参考
[vue-routerを使っったVueのSPAをVercelにホストするときの注意点](https://scrapbox.io/daikiojm/vue-router%E3%82%92%E4%BD%BF%E3%81%A3%E3%81%A3%E3%81%9FVue%E3%81%AESPA%E3%82%92Vercel%E3%81%AB%E3%83%9B%E3%82%B9%E3%83%88%E3%81%99%E3%82%8B%E3%81%A8%E3%81%8D%E3%81%AE%E6%B3%A8%E6%84%8F%E7%82%B9)

[vercel / rewrite](https://vercel.com/docs/cli#project-configuration/rewrites)