### PR TITLE
Develop : エラー対処

### DIFF
--- a/src/containers/LogedInHeader.tsx
+++ b/src/containers/LogedInHeader.tsx
@@ -37,15 +37,16 @@ const LoggedInHeader: VFC<LoggedInHeaderProps> = (props) => {
     setAnchorElUser(null)
   }
 
-  const storageRef = ref(storage, corderCurrentUser?.fileUrl)
-
-  getDownloadURL(storageRef)
-    .then((url) => {
-      setCorderAvator(url)
-    })
-    .catch(() => {
-      // Handle any errors
-    })
+  if (corderCurrentUser?.fileUrl) {
+    const storageRef = ref(storage, corderCurrentUser?.fileUrl)
+    getDownloadURL(storageRef)
+      .then((url) => {
+        setCorderAvator(url)
+      })
+      .catch(() => {
+        // Handle any errors
+      })
+  }
 
   return (
     <BaseHeader>


### PR DESCRIPTION
# 概要
* エラー対処

# エラー
### Uncaught FirebaseError: Firebase Storage: The operation 'getDownloadURL' cannot be performed on a root reference, create a non-root reference using child, such as .child('file.png'). (storage/invalid-root-operation)

# 参考
[AngularFireStorage.getDownloadUrl() is not handling the error properly](https://github.com/angular/angularfire/issues/2038)